### PR TITLE
Bug/missing dep issue 56

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ kcat.config
 tmp
 .vscode
 *.log
+.ropeproject

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ pydot
 colour
 cryptography
 sqllineage
+numpy


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

<!-- Provide a small sentence that summarizes the change. -->
- adds numpy as a dependency to requirements.txt
- updates gitignore for who uses pylsp-rope

<!-- Provide the issue number below if it exists. -->
Resolves: #56 

# Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->
- because having deps in requirements.txt is the standard
- update gitignore in this same PR as it doesn't seem to be worth opening a new PR
